### PR TITLE
Enabled ChainedAnalyses to observe an exception without killing the entire process.

### DIFF
--- a/src/js/instrument/esnstrument.js
+++ b/src/js/instrument/esnstrument.js
@@ -560,7 +560,7 @@ if (typeof J$ === 'undefined') {
     function wrapWithX1(node, ast) {
         if (!Config.INSTR_END_EXPRESSION || Config.INSTR_END_EXPRESSION(node)) {
 
-            if (!ast || ast.type.indexOf("Expression") <= 0 || ast.type.indexOf("SequenceExpression") >= 0) return ast;
+            if (!ast || ast.type.indexOf("Expression") <= 0) return ast;
             printIidToLoc(node);
             var ret = replaceInExpr(
                 logX1FunName + "(" + RP + "1," + RP + "2)", getIid(), ast);
@@ -1209,7 +1209,7 @@ if (typeof J$ === 'undefined') {
         },
         "SequenceExpression": function(node) {
             var i = 0, len = node.expressions.length;
-            for (i=0; i<len; i++) {
+            for (i=0; i<len - 1 /* the last expression is the result, do not wrap that */; i++) {
                 node.expressions[i] = wrapWithX1(node.expressions[i],node.expressions[i]);
             }
             return node;

--- a/src/js/sample_analyses/ChainedAnalyses.js
+++ b/src/js/sample_analyses/ChainedAnalyses.js
@@ -24,7 +24,7 @@
         function clientAnalysisException(e) {
             console.error("analysis exception!!!");
             console.error(e.stack);
-            if (typeof process !== 'undefined' && process.exit) {
+            if (typeof process !== 'undefined' && process.exit && !sandbox.Constants.isSingleTestProcess) {
                 process.exit(1);
             } else {
                 throw e;


### PR DESCRIPTION
Useful for doing unit testing without subprocesses