### PR TITLE
SequenceExpression & endExpression/X1 bugfix

### DIFF
--- a/src/js/instrument/esnstrument.js
+++ b/src/js/instrument/esnstrument.js
@@ -560,7 +560,7 @@ if (typeof J$ === 'undefined') {
     function wrapWithX1(node, ast) {
         if (!Config.INSTR_END_EXPRESSION || Config.INSTR_END_EXPRESSION(node)) {
 
-            if (!ast || ast.type.indexOf("Expression") <= 0 || ast.type.indexOf("SequenceExpression") >= 0) return ast;
+            if (!ast || ast.type.indexOf("Expression") <= 0) return ast;
             printIidToLoc(node);
             var ret = replaceInExpr(
                 logX1FunName + "(" + RP + "1," + RP + "2)", getIid(), ast);
@@ -1209,7 +1209,7 @@ if (typeof J$ === 'undefined') {
         },
         "SequenceExpression": function(node) {
             var i = 0, len = node.expressions.length;
-            for (i=0; i<len; i++) {
+            for (i=0; i<len - 1 /* the last expression is the result, do not wrap that */; i++) {
                 node.expressions[i] = wrapWithX1(node.expressions[i],node.expressions[i]);
             }
             return node;


### PR DESCRIPTION
A bug fix for SequenceExpression & endExpression/X1 bugfix.
Fixes #5 properly.

The examples I gave in #5 are slightly wrong.

The right specification is:
 - The last expression of a sequence expression should *never* be wrapped in X1.
 - If the entire sequence expression is a 'top level expression', then the sequence expression itself should be wrapped in X1.

Here is an example:
```
var a = ('a', 'b');
('a', 'b')
```
```
var a = J$.W(33, 'a', (J$.X1(25, J$.T(9, 'a', 21, false)), J$.T(17, 'b', 21, false)), a, false, true, true);
J$.X1(65, J$.T(49, 'a', 21, false)), J$.T(57, 'b', 21, false);
```