### PR TITLE
a bug in proxy.py

### DIFF
--- a/scripts/proxy.py
+++ b/scripts/proxy.py
@@ -34,6 +34,8 @@ def processFile (content, ext):
 		return content
 
 def start(context, argv):
+	global ANALYSES
+	global analysis
 	if len(argv) > 1:
 		ANALYSES = [os.path.abspath(os.path.join(WORKING_DIR,x)) for x in argv[1:]]
 		analysis = ' --analysis '.join([' ']+ANALYSES)


### PR DESCRIPTION
In function ```start``` if variable ```ANALYSES``` and ```analysis``` are not declared as global, the assignment statement will only create a local variable, assign a value to it and discard it. As a result, the analysis specified by the user is not set.