### PR TITLE
Added analysis callback for with() expression.

### DIFF
--- a/src/js/instrument/esnstrument.js
+++ b/src/js/instrument/esnstrument.js
@@ -89,6 +89,7 @@ if (typeof J$ === 'undefined') {
     var logTmpVarName = JALANGI_VAR + "._tm_p";
     var logSampleFunName = JALANGI_VAR + ".S";
 
+    var logWithFunName = JALANGI_VAR + ".Wi";
     var logBinaryOpFunName = JALANGI_VAR + ".B";
     var logUnaryOpFunName = JALANGI_VAR + ".U";
     var logConditionalFunName = JALANGI_VAR + ".C";
@@ -681,6 +682,21 @@ if (typeof J$ === 'undefined') {
                 logSwitchRightFunName + "(" + RP + "1, " + RP + "2)",
                 getCondIid(),
                 test
+            );
+            transferLoc(ret, node);
+            return ret;
+        } else {
+            return node;
+        }
+    }
+
+    function wrapWith(node) {
+        if (!Config.INSTR_CONDITIONAL || Config.INSTR_CONDITIONAL("with", node)) {
+            printIidToLoc(node);
+            var ret = replaceInExpr(
+                logWithFunName + "(" + RP + "1, " + RP + "2)",
+                getIid(),
+                node
             );
             transferLoc(ret, node);
             return ret;
@@ -1457,6 +1473,10 @@ if (typeof J$ === 'undefined') {
         },
         "FunctionDeclaration": function (node) {
             node.body.body = wrapFunBodyWithTryCatch(node, node.body.body);
+            return node;
+        },
+        "WithStatement": function (node) {
+            node.object = wrapWith(node.object);
             return node;
         },
         "ConditionalExpression": funCond,

--- a/src/js/runtime/analysis.js
+++ b/src/js/runtime/analysis.js
@@ -337,6 +337,16 @@ if (typeof J$ === 'undefined') {
         }
     }
 
+    function Wi(iid, val) {
+        if (sandbox.analysis && sandbox.analysis._with) {
+            aret = sandbox.analysis._with(iid, val);
+            if (aret) {
+                val = aret.result;
+            }
+        }
+        return val;
+    }
+
     // Uncaught exception
     function Ex(iid, e) {
         wrappedExceptionVal = {exception:e};
@@ -712,6 +722,7 @@ if (typeof J$ === 'undefined') {
     sandbox.Ex = Ex;
     sandbox.L = L;
     sandbox.X1 = X1; // top level expression
+    sandbox.Wi = Wi; // with statement
     sandbox.endExecution = endExecution;
 
     sandbox.S = S;

--- a/src/js/runtime/analysisCallbackTemplate.js
+++ b/src/js/runtime/analysisCallbackTemplate.js
@@ -63,6 +63,8 @@
 
         this._throw = function(iid, val){return {result:val};};
 
+        this._with = function(iid, val){return {result:val};};
+
         this.functionEnter = function (iid, f, dis, args){};
 
         this.functionExit = function(iid, returnVal, wrappedExceptionVal){return {returnVal:returnVal,wrappedExceptionVal:wrappedExceptionVal,isBacktrack:false};};

--- a/tests/test45.js
+++ b/tests/test45.js
@@ -1,0 +1,9 @@
+
+function testWith(x) {
+  with(x) {
+    console.log(foo.bar);
+  }
+}
+
+testWith({foo: {bar: 100}});
+


### PR DESCRIPTION
Needed this when I was analysing code that contained a with() block and I was replacing variables with symbolic value wrapper objects.