### PR TITLE
Updated instrument.js to follow convention of jalangi.js et al and name ...

### DIFF
--- a/src/js/commands/instrument.js
+++ b/src/js/commands/instrument.js
@@ -151,7 +151,7 @@ if (typeof J$ === 'undefined') {
 
             var instResult = sandbox.instrumentCode(options);
             var instrumentedCode = applyASTHandler(instResult);
-            fs.writeFileSync(path.join(copyDir, instname).replace(/.js$/, ".json"), instResult.sourceMapString, "utf8");
+            fs.writeFileSync(path.join(copyDir, instname).replace(/.js$/, "_jalangi_.json"), instResult.sourceMapString, "utf8");
             fs.writeFileSync(path.join(copyDir, origname), src);
             fs.writeFileSync(path.join(copyDir, instname), instrumentedCode);
             return instrumentedCode;
@@ -324,7 +324,7 @@ if (typeof J$ === 'undefined') {
             }
             if (instResult) {
                 var instrumentedCode = applyASTHandler(instResult);
-                fs.writeFileSync(this.instScriptName.replace(/.js$/, ".json"), instResult.sourceMapString, "utf8");
+                fs.writeFileSync(this.instScriptName.replace(/.js$/, "_jalangi_.json"), instResult.sourceMapString, "utf8");
                 this.push(instrumentedCode);
             }
             cb();


### PR DESCRIPTION
...smap files foo_jalangi_.json (to prevent overwriting foo.json files).

I had files named foo.js and foo.json, and running instrument.js on that directory was overwriting my foo.json files. Since "node jalangi.js foo.js" created the smap file as "foo_jalangi_.json", I figured instrument.js should do the same.