### PR TITLE
Added instrumentation to put function entry IID as a special property on...

### DIFF
--- a/src/js/Constants.js
+++ b/src/js/Constants.js
@@ -44,6 +44,7 @@ if (typeof J$ === 'undefined') {
     Constants.SPECIAL_PROP3 = "*" + PREFIX1 + "C*";
     Constants.SPECIAL_PROP4 = "*" + PREFIX1 + "W*";
     Constants.SPECIAL_PROP_SID = "*" + PREFIX1 + "SID*";
+    Constants.SPECIAL_PROP_IID = "*" + PREFIX1 + "IID*";
 
     Constants.UNKNOWN = -1;
 

--- a/src/js/instrument/esnstrument.js
+++ b/src/js/instrument/esnstrument.js
@@ -515,16 +515,46 @@ if (typeof J$ === 'undefined') {
         throw new Error(funId + " not known");
     }
 
+    function getFnIdFromAst(ast) {
+        var entryExpr = ast.body.body[0];
+        if (entryExpr.type != 'ExpressionStatement') { console.log(JSON.stringify(entryExpr)); throw new Error("IllegalStateException"); }
+        entryExpr = entryExpr.expression;
+        if (entryExpr.type != 'CallExpression') { throw new Error("IllegalStateException"); }
+        if (entryExpr.callee.type != 'MemberExpression') { throw new Error("IllegalStateException"); }
+        if (entryExpr.callee.object.name != JALANGI_VAR) { throw new Error("IllegalStateException"); }
+        if (entryExpr.callee.property.name != 'Fe') { throw new Error("IllegalStateException"); }
+        return entryExpr['arguments'][0].value;
+    }
+
     function wrapLiteral(node, ast, funId) {
         if (!Config.INSTR_LITERAL || Config.INSTR_LITERAL(getLiteralValue(funId, node), node)) {
             printIidToLoc(node);
             var hasGetterSetter = ifObjectExpressionHasGetterSetter(node);
-            var ret = replaceInExpr(
-                logLitFunName + "(" + RP + "1, " + RP + "2, " + RP + "3," + hasGetterSetter + ")",
-                getIid(),
-                ast,
-                createLiteralAst(funId)
-            );
+
+            var ret;
+            if (funId == N_LOG_FUNCTION_LIT) {
+                var internalFunId = null;
+                if (node.type == 'FunctionExpression') {
+                    internalFunId = getFnIdFromAst(node);
+                } else {
+                    if (node.type != 'Identifier') { throw new Error("IllegalStateException"); }
+                    internalFunId = getFnIdFromAst(scope.funNodes[node.name]);
+                }
+                ret = replaceInExpr(
+                    logLitFunName + "(" + RP + "1, " + RP + "2, " + RP + "3," + hasGetterSetter + ", " + internalFunId + ")",
+                    getIid(),
+                    ast,
+                    createLiteralAst(funId),
+                    internalFunId
+                );
+            } else {
+                ret = replaceInExpr(
+                    logLitFunName + "(" + RP + "1, " + RP + "2, " + RP + "3," + hasGetterSetter + ")",
+                    getIid(),
+                    ast,
+                    createLiteralAst(funId)
+                );
+            }
             transferLoc(ret, node);
             return ret;
         } else {
@@ -1471,13 +1501,14 @@ if (typeof J$ === 'undefined') {
         function Scope(parent, isCatch) {
             this.vars = {};
             this.funLocs = {};
+            this.funNodes = {};
             this.hasEval = false;
             this.hasArguments = false;
             this.parent = parent;
             this.isCatch = isCatch;
         }
 
-        Scope.prototype.addVar = function (name, type, loc) {
+        Scope.prototype.addVar = function (name, type, loc, node) {
             var tmpScope = this;
             if (this.isCatch && type !== 'catch') {
                 tmpScope = this.parent;
@@ -1488,6 +1519,7 @@ if (typeof J$ === 'undefined') {
             }
             if (type === 'defun') {
                 tmpScope.funLocs[name] = loc;
+                tmpScope.funNodes[name] = node;
             }
         };
 
@@ -1555,7 +1587,7 @@ if (typeof J$ === 'undefined') {
             currentScope = new Scope(currentScope);
             node.scope = currentScope;
             if (node.type === 'FunctionDeclaration') {
-                oldScope.addVar(node.id.name, "defun", node.loc);
+                oldScope.addVar(node.id.name, "defun", node.loc, node);
                 MAP(node.params, function (param) {
                     if (param.name === fromName) {         // rename arguments to J$_arguments
                         param.name = toName;
@@ -1767,7 +1799,7 @@ if (typeof J$ === 'undefined') {
                         // post-process AST to hoist function declarations (required for Firefox)
             var hoistedFcts = [];
             newAst = hoistFunctionDeclaration(newAst, hoistedFcts);
-            var newCode = esotope.generate(newAst);
+            var newCode = esotope.generate(newAst, {comment: true});
             code = newCode + "\n" + noInstr + "\n";
         }
 

--- a/src/js/runtime/analysis.js
+++ b/src/js/runtime/analysis.js
@@ -46,6 +46,7 @@ if (typeof J$ === 'undefined') {
     var EVAL_ORG = eval;
     var lastComputedValue;
     var SPECIAL_PROP_SID = sandbox.Constants.SPECIAL_PROP_SID;
+    var SPECIAL_PROP_IID = sandbox.Constants.SPECIAL_PROP_IID;
 
 
     var sidStack = [], sidCounter = 0;
@@ -61,15 +62,20 @@ if (typeof J$ === 'undefined') {
         sandbox.sid = sidStack.pop();
     }
 
-    function associateSidWithFunction(f) {
+    function associateSidWithFunction(f, iid) {
         if (typeof f === 'function') {
             if (Object && Object.defineProperty && typeof Object.defineProperty === 'function') {
                 Object.defineProperty(f, SPECIAL_PROP_SID, {
                     enumerable:false,
                     writable:true
                 });
+                Object.defineProperty(f, SPECIAL_PROP_IID, {
+                    enumerable:false,
+                    writable:true
+                });
             }
             f[SPECIAL_PROP_SID] = sandbox.sid;
+            f[SPECIAL_PROP_IID] = iid;
         }
     }
 
@@ -197,16 +203,16 @@ if (typeof J$ === 'undefined') {
 
     var hasGetOwnPropertyDescriptor = typeof Object.getOwnPropertyDescriptor === 'function';
     // object/function/regexp/array Literal
-    function T(iid, val, type, hasGetterSetter) {
+    function T(iid, val, type, hasGetterSetter, internalIid) {
         var aret;
-        associateSidWithFunction(val);
+        associateSidWithFunction(val, internalIid);
         if (hasGetterSetter) {
             for (var offset in val) {
                 if (hasGetOwnPropertyDescriptor && val.hasOwnProperty(offset)) {
                     var desc = Object.getOwnPropertyDescriptor(val, offset);
                     if (desc !== undefined) {
-                        associateSidWithFunction(desc.get);
-                        associateSidWithFunction(desc.set);
+                        associateSidWithFunction(desc.get, internalIid);
+                        associateSidWithFunction(desc.set, internalIid);
                     }
                 }
             }

--- a/tests/test46.js
+++ b/tests/test46.js
@@ -1,0 +1,9 @@
+
+function testDeclFun(x) {
+  console.log(x['*J$IID*']);
+  x();
+}
+
+console.log(testDeclFun['*J$IID*']);
+testDeclFun(function(y) {});
+


### PR DESCRIPTION
... functions.

I wanted to be able to get a function's IID (the IID passed to analysis.functionEnter) at the callsite of the function invoking it (i.e. in analysis.invokeFunPre). This changeset updates the instrumentation to pass this IID to J$.T() and sets it in the same way that the function gets its SID set. The process by which this IID is derived is kind of kludgy (it looks into the instrumented function AST and finds the IID being passed to J$.Fe), so it might be worth devising a better way to achieve this.