### PR TITLE
Updated analysis/instrumentation code to save Function and JSON referenc...

### DIFF
--- a/src/js/instrument/esnstrument.js
+++ b/src/js/instrument/esnstrument.js
@@ -32,6 +32,10 @@ if (typeof J$ === 'undefined') {
     if (typeof sandbox.instrumentCode !== 'undefined') {
         return;
     }
+
+    var global = this;
+    var JSON = { parse: global.JSON.parse, stringify: global.JSON.stringify };
+
     var astUtil = sandbox.astUtil;
 
     var Config = sandbox.Config;

--- a/src/js/runtime/analysis.js
+++ b/src/js/runtime/analysis.js
@@ -37,6 +37,8 @@ if (typeof J$ === 'undefined') {
     // have another function call in a finally block (see test
     // call_in_finally.js)
 
+    var global = this;
+    var Function = global.Function;
     var returnStack = [];
     var wrappedExceptionVal;
     var lastVal;

--- a/tests/test48.js
+++ b/tests/test48.js
@@ -1,0 +1,24 @@
+
+
+function doTheThing() {
+  return new Function('x', 'y', 'return x+y');
+}
+
+(function() {
+
+  var originalFunction = Function;
+  Function = function() { throw new Error("Eval not allowed."); };
+
+  var exceptionThrown = false;
+  try {
+    doTheThing();
+  } catch (e) {
+    exceptionThrown = true;
+  }
+  console.log(exceptionThrown);
+
+  Function = originalFunction;
+
+})();
+
+

--- a/tests/test49.js
+++ b/tests/test49.js
@@ -1,0 +1,21 @@
+
+
+function doTheThing(x, y) {
+  return eval('x+y');
+}
+
+(function() {
+
+  var originalJSONParse = JSON.parse;
+  var originalJSONStringify = JSON.stringify;
+  JSON.parse = function() { throw new Error("Should not call JSON.parse"); };
+  JSON.stringify = function() { throw new Error("Should not call JSON.stringify"); };
+
+  doTheThing();
+
+  JSON.parse = originalJSONParse;
+  JSON.stringify = originalJSONStringify;
+
+})();
+
+


### PR DESCRIPTION
...es since these are referred to in the analysis and may be overwritten by code-under-test.

I have several applications being analyzed which change the global Function and JSON objects, which breaks the runtime analysis. I updated the runtime analysis to save local copies of these objects.