### PR TITLE
support const from ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ If the proxy is currently enabled, the command disables the proxy.
 
 Refer to [docs/analysis.md](docs/analysis.md) and [docs/commands.md](docs/commands.md) for further information.
 
+### Supported ECMAScript versions
+
+Jalangi2 supports ECMAScript 5.1, plus the `const` construct from ECMAScript 6.  Other ES6 features may work, but have not been tested.
+
 License
 -------
 

--- a/src/js/instrument/esnstrument.js
+++ b/src/js/instrument/esnstrument.js
@@ -1796,7 +1796,7 @@ if (typeof J$ === 'undefined') {
 //         StatCollector.resumeTimer("parse");
 //        console.time("parse")
 //        var newAst = esprima.parse(code, {loc:true, range:true});
-        var newAst = acorn.parse(code, {locations: true});
+        var newAst = acorn.parse(code, {locations: true, ecmaVersion: 6 });
 //        console.timeEnd("parse")
 //        StatCollector.suspendTimer("parse");
 //        StatCollector.resumeTimer("transform");

--- a/tests/unit/es6_const.js
+++ b/tests/unit/es6_const.js
@@ -1,0 +1,2 @@
+const x = 3;
+console.log(x);

--- a/tests/unit/unitTests.txt
+++ b/tests/unit/unitTests.txt
@@ -1,3 +1,4 @@
+es6_const
 shebang
 cli_args fff
 instrument-test


### PR DESCRIPTION
I was trying to analyze some code that uses `const`, which apart from ES6 has also been supported in Firefox and node.js for a while.  As far as I can tell, things just work when I tell acorn to allow for ES6 constructs.  Of course, acorn will now also parse other ES6 constructs that we don't handle.  Maybe we should clarify the README about what language features we support?  @ksen007 thoughts?