### PR TITLE
Bugfix: wrapWriteWithUndefinedCheck using createBitPattern

### DIFF
--- a/src/js/instrument/esnstrument.js
+++ b/src/js/instrument/esnstrument.js
@@ -495,7 +495,7 @@ if (typeof J$ === 'undefined') {
 //            wrapRead(node, createLiteralAst(name),createIdentifierAst(name), true)
 //        );
             var ret = replaceInExpr(
-                logWriteFunName + "(" + RP + "1, " + RP + "2, " + RP + "3, " + logIFunName + "(typeof(" + lhs.name + ")==='undefined'?undefined:" + lhs.name + "), true, true)",
+                logWriteFunName + "(" + RP + "1, " + RP + "2, " + RP + "3, " + logIFunName + "(typeof(" + lhs.name + ")==='undefined'?undefined:" + lhs.name + ")," + createBitPattern(true, false, false) +")",
                 getIid(),
                 name,
                 val
@@ -1993,4 +1993,3 @@ if (typeof J$ === 'undefined') {
 // depends on J$.Constants
 // depends on J$.Config
 // depends on J$.astUtil
-


### PR DESCRIPTION
Bugfix: Made `wrapWriteWithUndefinedCheck` in esnstrument.js use a call to  `createBitPattern`  instead of multiple booleans.

# Example

Source
```javascript
var x = 'foo';
y = 'bar'
```

Formatted instrumentation without this patch.
```javascript
...
var x = J$.X1(25, J$.W(17, 'x', J$.T(9, 'foo', 21, false), x, 3));
J$.X1(49, y = 
    J$.W(41, 
             'y',
             J$.T(33, 'bar', 21, false), J$.I(typeof y === 'undefined' ? undefined : y),
             true, true // <<<< BOOLEANS
));
...
```

Formatted instrumentation with this patch.
```javascript
...
var x = J$.X1(25, J$.W(17, 'x', J$.T(9, 'foo', 21, false), x, 3));
J$.X1(49, y = 
    J$.W(41, 
             'y',
             J$.T(33, 'bar', 21, false), J$.I(typeof y === 'undefined' ? undefined : y),
             4 // <<<< FLAGS
));
...
```