### PR TITLE
Fix #63. A JSONStringifyHandler is used to stringify RegExps instead of mutating RegExp.prototype.toJSON.

### DIFF
--- a/src/js/instrument/esnstrument.js
+++ b/src/js/instrument/esnstrument.js
@@ -1239,7 +1239,7 @@ if (typeof J$ === 'undefined') {
         return node;
     }
 
-    RegExp.prototype.toJSON = function () {
+    function regExpToJSON() {
         var str = this.source;
         var glb = this.global;
         var ignoreCase = this.ignoreCase;
@@ -1257,6 +1257,8 @@ if (typeof J$ === 'undefined') {
     function JSONStringifyHandler(key, value) {
         if (key === 'scope') {
             return undefined;
+        } if (value instanceof RegExp) {
+            return regExpToJSON.call(value);
         } else {
             return value;
         }

--- a/tests/test50.js
+++ b/tests/test50.js
@@ -1,0 +1,5 @@
+for(var p in RegExp.prototype){
+  console.log(p);
+}
+
+console.log(RegExp.prototype.toJSON + '');


### PR DESCRIPTION
Note: You might want to rewrite the changed code to be a direct call without the indirection through .call, but the regExpToJSON function needs some changes too then.

`npm test` has been run successfully.

A test file has been added (/tests/test50.js), but the process for adding tests to Jalangi is not described anywhere?