### PR TITLE
Proxy

### DIFF
--- a/scripts/proxy.py
+++ b/scripts/proxy.py
@@ -1,52 +1,114 @@
-
 import hashlib
 import os
 import sys
 import inspect
+import traceback
+
+from libmproxy.script import concurrent
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
-JALANGI_HOME = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(filename)),os.pardir))
-ANALYSES=[JALANGI_HOME+'/src/js/sample_analyses/ChainedAnalyses.js', JALANGI_HOME+'/src/js/runtime/analysisCallbackTemplate.js']
+JALANGI_HOME = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(filename)), os.pardir))
 WORKING_DIR = os.getcwd()
-
-print "Jalangi home is "+JALANGI_HOME
-print "Current working directory is "+WORKING_DIR
 
 sys.path.insert(0, JALANGI_HOME+'/scripts')
 import sj
 
-extraArgs = ' --analysis '.join([' ']+ANALYSES)
+print('Jalangi home is ' + JALANGI_HOME)
+print('Current working directory is ' + WORKING_DIR)
 
-def processFile (content, ext):
-	try:
-		fileName = hashlib.md5(content).hexdigest()
-		if not os.path.isfile(fileName+'.'+ext):
-			print "Storing and instrumenting "+fileName+"."+ext
-			with open(fileName+"."+ext, "w") as text_file:
-				text_file.write(content)
-			sj.execute(sj.INSTRUMENTATION_SCRIPT+' --inlineIID --inlineSource '+extraArgs+' '+fileName+'.'+ext)
-		with open (fileName+"_jalangi_."+ext, "r") as text_file:
-			data = text_file.read()
-		return data
-	except:
-		print "Exception in proxy.py"
-		print sys.exc_info()
-		return content
+jalangiArgs = ''
+useCache = True
+ignore = []
 
+def processFile (flow, content, ext):
+    try:
+        url = flow.request.scheme + '://' + flow.request.host + ':' + str(flow.request.port) + flow.request.path
+        name = os.path.splitext(flow.request.path_components[-1])[0] if len(flow.request.path_components) else 'index'
+
+        hash = hashlib.md5(content).hexdigest()
+        fileName = 'cache/' + flow.request.host + '/' + hash + '/' + name + '.' + ext
+        instrumentedFileName = 'cache/' + flow.request.host + '/' + hash + '/' + name + '_jalangi_.' + ext
+        if not os.path.exists('cache/' + flow.request.host + '/' + hash):
+            os.makedirs('cache/' + flow.request.host + '/' + hash)
+        if not useCache or not os.path.isfile(instrumentedFileName):
+            print('Instrumenting: ' + fileName + ' from ' + url)
+            with open(fileName, 'w') as file:
+                file.write(content)
+            sub_env = { 'JALANGI_URL': url }
+            sj.execute(sj.INSTRUMENTATION_SCRIPT + ' ' + jalangiArgs + ' ' + fileName + ' --out ' + instrumentedFileName + ' --outDir ' + os.path.dirname(instrumentedFileName), sub_env)
+        else:
+            print('Already instrumented: ' + fileName + ' from ' + url)
+        with open (instrumentedFileName, "r") as file:
+            data = file.read()
+        return data
+    except:
+        print('Exception in processFile() @ proxy.py')
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+        print(''.join(lines))
+        return content
+
+# Example usage: "proxy.py --no-cache --ignore http://cdn.com/jalangi --inlineIID --inlineSource --noResultsGUI --analysis ..."
 def start(context, argv):
-        global extraArgs
-	if len(argv) > 1:
-                def mapper(p): return p if p.startswith('--') else os.path.abspath(os.path.join(WORKING_DIR,p))
-                extraArgs = ' '.join(map(mapper, [x for x in argv[1:]]))
-                print extraArgs
+    global jalangiArgs
+    global useCache
 
+    # For enabling/disabling instrumentation cache (enabled by default)
+    if '--no-cache' in argv:
+        print('Cache disabled.')
+        useCache = False
+        argv.remove('--no-cache')
+    elif '--cache' in argv:
+        argv.remove('--cache')
+
+    # For not invoking jalangi for certain URLs
+    ignoreIdx = argv.index('--ignore') if '--ignore' in argv else -1
+    while ignoreIdx >= 0:
+        argv.pop(ignoreIdx)
+        ignore.append(argv[ignoreIdx])
+        argv.pop(ignoreIdx)
+        ignoreIdx = argv.index('--ignore') if '--ignore' in argv else -1
+
+    # The remaining arguments are passed to jalangi
+    def mapper(p):
+        path = os.path.abspath(os.path.join(WORKING_DIR, p))
+        return path if not p.startswith('--') and (os.path.isfile(path) or os.path.isdir(path)) else p
+    jalangiArgs = ' '.join(map(mapper, [x for x in argv[1:]]))
+
+@concurrent
 def response(context, flow):
-	flow.response.decode()
-	if 'Content-Type' in flow.response.headers:
-		if flow.response.headers['Content-Type'][0].find('javascript') != -1:
-			flow.response.content = processFile(flow.response.content, "js")
-		if flow.response.headers['Content-Type'][0].find('html') != -1:
-			flow.response.content = processFile(flow.response.content, "html")
+    # Do not invoke jalangi if the domain is ignored
+    for path in ignore:
+        if flow.request.url.startswith(path):
+            return
 
+    # Do not invoke jalangi if the requested URL contains the query parameter noInstr
+    # (e.g. https://cdn.com/jalangi/jalangi.min.js?noInstr=true)
+    if flow.request.query and flow.request.query['noInstr']:
+        return
 
+    try:
+        flow.response.decode()
 
+        content_type = None
+        csp_key = None
+        for key in flow.response.headers.keys():
+            if key.lower() == "content-type":
+                content_type = flow.response.headers[key].lower()
+            elif key.lower() == "content-security-policy":
+                csp_key = key
+
+        if content_type:
+            if content_type.find('javascript') >= 0:
+                flow.response.content = processFile(flow, flow.response.content, 'js')
+            if content_type.find('html') >= 0:
+                flow.response.content = processFile(flow, flow.response.content, 'html')
+
+        # Disable the content security policy since it may prevent jalangi from executing
+        if csp_key:
+            flow.response.headers.pop(csp_key, None)
+    except:
+        print('Exception in response() @ proxy.py')
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+        print(''.join(lines))


### PR DESCRIPTION
This pull request proposes a number of fixes to the proxy, and should solve issues #66, #70, #77, and #78:

* #66: Rather than storing files as `<hash>.<ext>` they are stored as `<domain>/<hash>/<name>.<ext>`. URL's without a filename, e.g. `sra.samsung.com`, will be stored as `<domain>/<hash>/index.<ext>`.

  This makes it significantly easier to locate the instrumented source files. For example, the instrumented version of `foo.bar/baz.js` can be located simply by `find . -name baz.js`.

  In addition, the environment variable `JALANGI_URL` is set to the source URL. This can be useful for NodeJS modules passed to Jalangi2 using the `--astHandlerModule` option, for example, in order to load a configuration file associated with the URL of the web page being analyzed.

* #70: The content type is now checked case insensitively.

* #77: The proxy now runs on the current release of mitmproxy, v. 0.15.

* #78: The problem is that the instrumented version of the file is believed to be in the cache if `<hash>.js` is a file on the disk, and not if `<hash>_jalangi_.js` is a file on the disk (<https://github.com/Samsung/jalangi2/blob/master/scripts/proxy.py#L23>).

  In addition, an option `--no-cache` is now handled by the `proxy.py` script for the purpose of development.

The pull request also:

1. Removes the need for running the proxy script from inside a `tmp/` folder; it will automatically store the files in a folder named `cache/`.
2. Adds an option `--auto-disable` to the `mitmproxywrapper.py` script, which automatically disables the proxy when the script is interrupted (rather than having to rerun the script).
3. Removes content security policies since they may block jalangi from executing