### PR TITLE
HTML instrumentation using rewriting-proxy v. 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,17 +5,18 @@
   "dependencies": {
     "acorn": "1.0.3",
     "argparse": "0.1.6",
+    "codemirror": "5.1.0",
     "cover": "0.2.9",
+    "datatables": "1.10.6",
     "esotope": "1.4.5",
     "estraverse": "4.0.0",
+    "jquery": "2.1.3",
     "mkdirp": "0.5.0",
     "ncp": "0.6.0",
-    "rewriting-proxy": "0.4.2",
-    "temp": "0.8.1",
+    "parse5": "2.1.5",
     "q": "1.2.0",
-    "codemirror": "5.1.0",
-    "jquery": "2.1.3",
-    "datatables": "1.10.6"
+    "rewriting-proxy": "0.5.0",
+    "temp": "0.8.1"
   },
   "bundledDependencies": [
     "acorn",


### PR DESCRIPTION
This pull request makes jalangi more robust by leveraging version 0.5.0 of the rewriting-proxy module to instrument HTML.

For example, jalangi would no longer rely on the assumption (from `insertStringAfterBeforeTag`) that the head-tag is written `<head>` or `<HEAD>`, and thereby cannot have any attributes.

The better HTML instrumentation capabilities are also used to remove `integrity` attributes from script tags, which would otherwise cause instrumented scripts to be blocked (see [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)).

Finally, the pull request provides an option `--htmlVisitorModule` (similar to the `--astHandlerModule` flag), which can be used to specify a NodeJS module for custom HTML instrumentation. The module should export two properties: `onNodeVisited` (a function that may mutate the HTML DOM) and `locationInfo` (a boolean determining whether the HTML parser should include location data; disabled by default for performance). For additional details, see [the rewriting-proxy module](https://github.com/msridhar/rewriting-proxy).
