### PR TITLE
CDN option

### DIFF
--- a/src/js/commands/esnstrument_cli.js
+++ b/src/js/commands/esnstrument_cli.js
@@ -121,6 +121,7 @@ if (typeof J$ === 'undefined') {
         parser.addArgument(['--inlineSource'], {help: "Inline original source as string in J$.iids.code in the instrumented file", action: 'storeTrue'});
         parser.addArgument(['--initParam'], { help: "initialization parameter for analysis, specified as key:value", action:'append'});
         parser.addArgument(['--noResultsGUI'], { help: "disable insertion of results GUI code in HTML", action:'storeTrue'});
+        parser.addArgument(['--cdn'], {help: "CDN URL from which to serve analysis (rather than inlining)"});
         parser.addArgument(['--astHandlerModule'], {help: "Path to a node module that exports a function to be used for additional AST handling after instrumentation"});
         parser.addArgument(['--htmlVisitorModule'], {help: "Path to a node module that exports a function to be used for HTML handling before instrumentation"});
         parser.addArgument(['--outDir'], {
@@ -147,6 +148,13 @@ if (typeof J$ === 'undefined') {
         });
         var args = parser.parseArgs();
 
+        var cdn = null;
+        if (args.cdn) {
+            cdn = args.cdn;
+            if (cdn[cdn.length-1] === '/') {
+                cdn = cdn.substring(0, cdn.length-1);
+            }
+        }
         var astHandler = null;
         if (args.astHandlerModule) {
             astHandler = require(args.astHandlerModule);

--- a/src/js/instrument/instUtil.js
+++ b/src/js/instrument/instUtil.js
@@ -44,36 +44,51 @@ function setHeaders() {
 }
 
 
-function getInlinedScripts(analyses, initParams, extraAppScripts, EXTRA_SCRIPTS_DIR, jalangiRoot) {
+function getInlinedScripts(analyses, initParams, extraAppScripts, EXTRA_SCRIPTS_DIR, jalangiRoot, cdn) {
     if (!headerCode) {
-        headerSources.forEach(function (src) {
-            if (jalangiRoot) {
-                src = path.join(jalangiRoot, src);
-            }
-            headerCode += "<script type=\"text/javascript\">";
-            headerCode += fs.readFileSync(src);
-            headerCode += "</script>";
-        });
-
-        if (analyses) {
-            headerCode += genInitParamsCode(initParams);
-            analyses.forEach(function (src) {
-                src = path.resolve(src);
+        if (cdn) {
+            headerCode += "<script type=\"text/javascript\" src=\"" + cdn + "/jalangi.js\"></script>";
+        } else {
+            headerSources.forEach(function (src) {
+                if (jalangiRoot) {
+                    src = path.join(jalangiRoot, src);
+                }
                 headerCode += "<script type=\"text/javascript\">";
                 headerCode += fs.readFileSync(src);
                 headerCode += "</script>";
             });
         }
 
+        if (analyses) {
+            var initParamsCode = genInitParamsCode(initParams);
+            if (initParamsCode) {
+                headerCode += initParamsCode;
+            }
+            if (cdn) {
+                headerCode += "<script type=\"text/javascript\" src=\"" + cdn + "/analyses.js\"></script>";
+            } else {
+                analyses.forEach(function (src) {
+                    src = path.resolve(src);
+                    headerCode += "<script type=\"text/javascript\">";
+                    headerCode += fs.readFileSync(src);
+                    headerCode += "</script>";
+                });
+            }
+        }
+
         if (extraAppScripts.length > 0) {
             // we need to inject script tags for the extra app scripts,
             // which have been copied into the app directory
-            extraAppScripts.forEach(function (script) {
-                var scriptSrc = path.join(EXTRA_SCRIPTS_DIR, path.basename(script));
-                headerCode += "<script type=\"text/javascript\">";
-                headerCode += fs.readFileSync(scriptSrc);
-                headerCode += "</script>";
-            });
+            if (cdn) {
+                headerCode += "<script type=\"text/javascript\" src=\"" + cdn + "/extras.js\"></script>";
+            } else {
+                extraAppScripts.forEach(function (script) {
+                    var scriptSrc = path.join(EXTRA_SCRIPTS_DIR, path.basename(script));
+                    headerCode += "<script type=\"text/javascript\">";
+                    headerCode += fs.readFileSync(scriptSrc);
+                    headerCode += "</script>";
+                });
+            }
         }
     }
     return headerCode;


### PR DESCRIPTION
Adds an option `--cdn <url>` to jalangi.

When the option is used, the jalangi and analysis source files will be served from the CDN, rather than being inlined in the HTML:
```
<script type="text/javascript" src="<url>/jalangi.js"></script>
<script type="text/javascript" src="<url>/analyses.js"></script>
<script type="text/javascript" src="<url>/extras.js"></script>
```
(The file `extras.js` is only included if `extraAppScripts` is non-empty.)

This significantly improves the loading time of web applications in the browser, since the instrumented HTML files are much smaller and `jalangi.js` and `analyses.js` can be cached. Since the analyses are also served from the CDN, it is the client's responsibility to host (and minify) the files.
