### PR TITLE
Use newest version of acorn

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.4",
   "description": "dynamic analysis framework for JavaScript",
   "dependencies": {
-    "acorn": "1.0.3",
+    "acorn": "3.1.0",
     "argparse": "0.1.6",
     "codemirror": "5.1.0",
     "cover": "0.2.9",


### PR DESCRIPTION
Jalangi currently depends on acorn 1.0.3, which (among other issues) doesn't support template strings. This pull request bumps up the required acorn version to the newest version (3.1.0). I ran both "python scripts/test.analysis.py" and "python scripts/test.dlint.py". All tests pass.