### PR TITLE
Check for undefined or null functions. Fixes #96

### DIFF
--- a/src/js/runtime/analysis.js
+++ b/src/js/runtime/analysis.js
@@ -186,6 +186,8 @@ if (typeof J$ === 'undefined') {
                 result = invokeFunctionDecl(base, f, args, iid);
             } else if (isConstructor) {
                 result = callAsConstructor(f, args);
+            } else if (typeof f === 'undefined' || f === null){
+                result = undefined;
             } else {
                 result = Function.prototype.apply.call(f, base, args);
             }
@@ -199,7 +201,11 @@ if (typeof J$ === 'undefined') {
         var aret, skip = false, result;
 
         if (sandbox.analysis && sandbox.analysis.invokeFunPre) {
-            aret = sandbox.analysis.invokeFunPre(iid, f, base, args, isConstructor, isMethod, f[SPECIAL_PROP_IID], f[SPECIAL_PROP_SID]);
+            if (typeof f === 'undefined' || f === null){
+                aret = sandbox.analysis.invokeFunPre(iid, f, base, args, isConstructor, isMethod, undefined, undefined);
+            } else {
+                aret = sandbox.analysis.invokeFunPre(iid, f, base, args, isConstructor, isMethod, undefined, undefined);
+            }
             if (aret) {
                 f = aret.f;
                 base = aret.base;
@@ -211,7 +217,11 @@ if (typeof J$ === 'undefined') {
             result = callFun(f, base, args, isConstructor, iid);
         }
         if (sandbox.analysis && sandbox.analysis.invokeFun) {
-            aret = sandbox.analysis.invokeFun(iid, f, base, args, result, isConstructor, isMethod, f[SPECIAL_PROP_IID], f[SPECIAL_PROP_SID]);
+            if (typeof f === 'undefined' || f === null){
+                aret = sandbox.analysis.invokeFun(iid, f, base, args, result, isConstructor, isMethod, undefined, undefined);
+            } else {
+                aret = sandbox.analysis.invokeFun(iid, f, base, args, result, isConstructor, isMethod, f[SPECIAL_PROP_IID], f[SPECIAL_PROP_SID]);
+            }
             if (aret) {
                 result = aret.result;
             }


### PR DESCRIPTION
- Add checks for undefined or null functions and pass in undefined  f[SPECIAL_PROP_IID] and f[SPECIAL_PROP_SID] to avoid TypErrors from reading the property of an undefined or null
- If the function is undefined or null return the result of function as undefined.
