### PR TITLE
Make an NPM runnable

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     "mocha": "^2.4.5",
     "shelljs": "^0.6.0"
   },
-  "main": "src/js/utils/api.js"
+  "main": "src/js/utils/api.js",
+  "bin": "src/js/commands/jalangi.js"
 }

--- a/src/js/commands/jalangi.js
+++ b/src/js/commands/jalangi.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*
  * Copyright 2014 Samsung Information Systems America, Inc.
  *


### PR DESCRIPTION
This change lets NPM recognize Jalangi2 as a command-line executable.

For a default NodeJS setup, this change would enable the following pattern:
```
$ npm install -g jalangi2
$ jalangi2 <args>
```

