### PR TITLE
Fix:What sandbox.N(variable declaration) returns is not assigned to aret

### DIFF
--- a/src/js/runtime/analysis.js
+++ b/src/js/runtime/analysis.js
@@ -294,9 +294,9 @@ if (typeof J$ === 'undefined') {
         }
         if (!bFlags[1] && sandbox.analysis && sandbox.analysis.declare) {
             if (bFlags[0] && argIndex > 1) {
-                sandbox.analysis.declare(iid, name, val, bFlags[0], argIndex - 2, bFlags[2]);
+                aret = sandbox.analysis.declare(iid, name, val, bFlags[0], argIndex - 2, bFlags[2]);
             } else {
-                sandbox.analysis.declare(iid, name, val, bFlags[0], -1, bFlags[2]);
+                aret = sandbox.analysis.declare(iid, name, val, bFlags[0], -1, bFlags[2]);
             }
             if (aret) {
                 val = aret.result;


### PR DESCRIPTION
The object that analysis.declare returns doesn't assign to variable aret so that the original initial value can't be replaced.I modified it but not really sure if it's a bug because i suppose there is a possibility that the return value is needed to be ignored temporarily for some reason.