### PR TITLE
Add missing iid too iid-map for inc-dec operations

### DIFF
--- a/src/js/instrument/esnstrument.js
+++ b/src/js/instrument/esnstrument.js
@@ -1176,9 +1176,9 @@ if (typeof J$ === 'undefined') {
 
             var tmp2;
             if (scope.hasVar(node.left.name)) {
-                tmp2 = wrapWrite(node.right, createLiteralAst(node.left.name), tmp1, node.left, false, scope.isGlobal(node.left.name), false);
+                tmp2 = wrapWrite(node, createLiteralAst(node.left.name), tmp1, node.left, false, scope.isGlobal(node.left.name), false);
             } else {
-                tmp2 = wrapWriteWithUndefinedCheck(node.right, createLiteralAst(node.left.name), tmp1, node.left);
+                tmp2 = wrapWriteWithUndefinedCheck(node, createLiteralAst(node.left.name), tmp1, node.left);
 
             }
             tmp2 = wrapLHSOfModStore(node, node.left, tmp2);


### PR DESCRIPTION
This pull request adds an iid entry for the write-part of pre- and postfix operations on variables.

The pull request has successfully been tested with npm test.

The pull request diff is very minor, I suspect that some acorn-change have caused the problem.

## Problem

An analysis that prints the locations `.write` and `.putFieldPre` does
not print a nice location for the `write` operation of pre- and
postfix operations on variables:

Run of Jalangi (current master HEAD):

```
$ src/js/commands/jalangi.js --inlineIID --analysis ANALYSIS.js PROGRAM.js
(sid === 1, iid == 25) -> location == (PROGRAM.js:iid25)
(sid === 1, iid == 57) -> location == (PROGRAM.js:iid57)
(sid === 1, iid == 97) -> location == (PROGRAM.js:iid97)
(sid === 1, iid == 129) -> location == (PROGRAM.js:iid129)
(sid === 1, iid == 169) -> location == (PROGRAM.js:9:3:9:11)
(sid === 1, iid == 209) -> location == (PROGRAM.js:10:3:10:11)
(sid === 1, iid == 241) -> location == (PROGRAM.js:12:3:12:13)
(sid === 1, iid == 281) -> location == (PROGRAM.js:13:3:13:13)
```

PROGRAM.js:
```javascript
(function(){
  ++toString;
  toString++;

  var x;
  ++x;
  x++;

  this.x++;
  ++this.x;

  (this).x++;
  ++(this).x
})();
```

ANALYSIS.js:
```javascript
(function (sandbox) {
  function printLocation(iid){
    var sid = sandbox.sid;
    var location = sandbox.iidToLocation(sid, iid);
    console.log("(sid === %s, iid == %s) -> location == %s", sid, iid, location);
  }
  sandbox.analysis = {
    write: function(iid, name, val, lhs, isGlobal, isScriptLocal){
      printLocation(iid);
    },
    putFieldPre: function (iid, base, offset, val, isComputed, isOpAssign) {
      printLocation(iid);
    }
  };
})(J$);
```

## Fixed output

Run of Jalangi (this pull request):

```
$ src/js/commands/jalangi.js --inlineIID --analysis ANALYSIS.js PROGRAM.js
(sid === 1, iid == 25) -> location == (PROGRAM.js:2:3:2:13)
(sid === 1, iid == 57) -> location == (PROGRAM.js:3:3:3:13)
(sid === 1, iid == 97) -> location == (PROGRAM.js:6:3:6:6)
(sid === 1, iid == 129) -> location == (PROGRAM.js:7:3:7:6)
(sid === 1, iid == 169) -> location == (PROGRAM.js:9:3:9:11)
(sid === 1, iid == 209) -> location == (PROGRAM.js:10:3:10:11)
(sid === 1, iid == 241) -> location == (PROGRAM.js:12:3:12:13)
(sid === 1, iid == 281) -> location == (PROGRAM.js:13:3:13:13)
```
