### PR TITLE
Bump acorn to fix bug with eval

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.5",
   "description": "dynamic analysis framework for JavaScript",
   "dependencies": {
-    "acorn": "3.1.0",
+    "acorn": "7.2.0",
     "argparse": "0.1.6",
     "codemirror": "5.1.0",
     "cover": "0.2.9",

--- a/tests/unit/obj_prototype_eval.js
+++ b/tests/unit/obj_prototype_eval.js
@@ -1,0 +1,5 @@
+function f(){
+       return eval("3");
+}
+Object.prototype.g=function(){ throw "should not be called!"; }
+f();

--- a/tests/unit/unitTests.txt
+++ b/tests/unit/unitTests.txt
@@ -1,3 +1,4 @@
+obj_prototype_eval
 shebang
 cli_args fff
 instrument-test


### PR DESCRIPTION
The old version of acorn used a `for-in` loop while loading plugins, which would invoke any function present on `Object.prototype`.  The bug is described in this paper:

https://www.crysys.hu/publications/files/setit/cpaper_szte_HerczegL19enase.pdf


