### PR TITLE
Fix numeric coercion for property update expressions

### DIFF
--- a/src/js/instrument/esnstrument.js
+++ b/src/js/instrument/esnstrument.js
@@ -366,11 +366,11 @@ if (typeof J$ === 'undefined') {
         }
     }
 
-    function wrapModAssign(node, base, offset, op, rvalue, isComputed) {
+    function wrapModAssign(node, base, offset, op, rvalue, isComputed, isNumber) {
         if (!Config.INSTR_PROPERTY_BINARY_ASSIGNMENT || Config.INSTR_PROPERTY_BINARY_ASSIGNMENT(op, node.computed ? null : offset.value, node)) {
             printModIidToLoc(node);
             var ret = replaceInExpr(
-                logAssignFunName + "(" + RP + "1," + RP + "2," + RP + "3," + RP + "4," + (createBitPattern(isComputed)) + ")(" + RP + "5)",
+                logAssignFunName + "(" + RP + "1," + RP + "2," + RP + "3," + RP + "4," + (createBitPattern(isComputed, isNumber)) + ")(" + RP + "5)",
                 getIid(),
                 base,
                 offset,
@@ -1187,7 +1187,7 @@ if (typeof J$ === 'undefined') {
             var ret = wrapModAssign(node, node.left.object,
                 getPropertyAsAst(node.left),
                 node.operator.substring(0, node.operator.length - 1),
-                node.right, node.left.computed);
+                node.right, node.left.computed, !!isNumber);
             return ret;
         }
     }

--- a/src/js/runtime/analysis.js
+++ b/src/js/runtime/analysis.js
@@ -517,9 +517,12 @@ if (typeof J$ === 'undefined') {
 
     // Modify and assign +=, -= ...
     function A(iid, base, offset, op, flags) {
-        var bFlags = decodeBitPattern(flags, 1); // [isComputed]
+        var bFlags = decodeBitPattern(flags, 2); // [isComputed, isNumber]
         // avoid iid collision: make sure that iid+2 has the same source map as iid (@todo)
         var oprnd1 = G(iid+2, base, offset, createBitPattern(bFlags[0], true, false));
+        if (bFlags[1]) {
+            oprnd1 = +oprnd1;
+        }
         return function (oprnd2) {
             // still possible to get iid collision with a mem operation
             var val = B(iid, op, oprnd1, oprnd2, createBitPattern(false, true, false));

--- a/tests/unit/prop_inc_nan.js
+++ b/tests/unit/prop_inc_nan.js
@@ -1,0 +1,5 @@
+var obj = { foo: 'bar' };
+obj.foo++;
+
+// should be NaN
+console.log(obj.foo);

--- a/tests/unit/unitTests.txt
+++ b/tests/unit/unitTests.txt
@@ -45,6 +45,7 @@ new_function_toString
 object_lit
 object_tracking
 op_assign
+prop_inc_nan
 prototype_property
 scope_rr
 shadow-arguments-real


### PR DESCRIPTION
I noticed a semantic mismatch in how property modify-and-assign operations are handled compared to the JavaScript specification.

When performing an increment operation on an object property whose value is not already numeric, the required coercion is not applied. As a result, operations such as obj.foo++ can produce behavior that diverges from standard JavaScript semantics.

This PR fixes the issue by propagating numeric context information through the modify-and-assign instrumentation and applying ToNumber coercion at runtime. A unit test has been added to capture this edge case and prevent regressions.

### Example Demonstrating the Issue

This issue can be reproduced independently of analysis.js:

```js
var foo = 'bar';
var obj = { foo: 'bar' };
foo++;
obj.foo++;

console.log(foo, obj.foo);
// `foo` prints NaN in both node and Jalangi.
// `obj.foo` prints NaN in node, but 'bar1' in Jalangi.
```